### PR TITLE
레이아웃 변경으로 상단바 분리

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,12 +1,5 @@
-/* 상단 바 다른 거 쓰는 법 (기본값 hasBackBtn)
-각 페이지 파일에서
-<Layout hasBackBtn/> => 뒤로가기 버튼만 있는 상단 바
-<Layout hasLogo /> => 로고만 있는 상단 바
-<Layout title="얼그레이"/> => 뒤로가기 버튼과 얼그레이가 적힌 상단 바 (title에 변수 string 가능)
-*/
-
 import { Outlet, useLocation } from 'react-router-dom';
-import AppBar, { AppBarProps } from '@/components/Main/AppBar';
+import { AppBarProps } from '@/components/Main/AppBar';
 import BottomNav from '@/components/Main/BottomNav';
 
 interface LayoutProps extends AppBarProps {}
@@ -30,8 +23,7 @@ export default function RootLayout({
             <AppBar hasBackBtn={hasBackBtn} hasLogo={hasLogo} title={title} />
          )} */}
 
-         <AppBar hasBackBtn={hasBackBtn} hasLogo={hasLogo} title={title} />
-         <main className="content h-screen overflow-y-scroll bg-stone-100 px-8 py-16">
+         <main className="content h-screen overflow-y-scroll bg-stone-100 px-8">
             <Outlet />
          </main>
          <BottomNav />

--- a/src/pages/Join/MyTastePage.tsx
+++ b/src/pages/Join/MyTastePage.tsx
@@ -64,4 +64,4 @@ export function Component() {
          </main>
       </>
    );
-
+}

--- a/src/pages/Main/MainPage.tsx
+++ b/src/pages/Main/MainPage.tsx
@@ -1,10 +1,10 @@
 import SearchInput from '@/components/Input/SearchInput';
-// import RootLayout from '@/layouts/RootLayout';
+import AppBar from '@/components/Main/AppBar';
 
 export default function MainPage() {
    return (
       <>
-         {/* <RootLayout hasLogo /> */}
+         <AppBar hasLogo />
          <SearchInput isButton={true} />
       </>
    );


### PR DESCRIPTION
### 설명
레이아웃, 상하단바 css 변경 이후 현재 pr 승인 전 작업하는 각 페이지 위에
`<RootLayout hasLogo/>`를 입력해 보면
레이아웃 속의 레이아웃이 발생하여 임시로 상단 바를 분리

### PR 유형
- [x] 버그 수정
- [x] 코드 리팩터링

### PR 체크 리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
